### PR TITLE
Fix struct conflict and build path issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ NAME	=	minishell
 CC		=	cc
 FLAG	=	-Wall -Wextra -Werror -g3
 
-DIRLIB	=	./Libft/
+DIRLIB	=	./libft/
 FILELIB	=	libft.a
 NAMELFT	=	$(addprefix $(DIRLIB), $(FILELIB))
 
 SRC_DIR	=	src/
 OBJ_DIR	=	obj/
-INCLUDE	=	-I ./include -I ./Libft
+INCLUDE	=	-I ./include -I ./libft
 HEADER 	=	include/minishell.h
 
 # Color

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -23,8 +23,8 @@
 # include <sys/stat.h>
 # include <readline/readline.h>
 # include <readline/history.h>
-# include "../Libft/src/libft.h"
-# include "../Libft/src/get_next_line.h"
+# include "../libft/libft.h"
+# include "../libft/get_next_line/get_next_line.h"
 
 # define INPUT		1	//"<"
 # define HEREDOC	2	//"<<"
@@ -62,16 +62,16 @@ typedef struct s_token
 	struct s_token	*next;
 }				t_token;
 
-typedef struct s_list
+typedef struct s_node
 {
 	char			*str;
-	struct s_list	*prev;
-	struct s_list	*next;
-}					t_list;
+	struct s_node  *prev;
+	struct s_node  *next;
+}                                       t_node;
 
 typedef struct s_data
 {
-	t_list	*env;
+	t_node	*env;
 	t_token	*token;
 	t_cmd	*cmd;
 	int		exit_code;
@@ -83,9 +83,9 @@ typedef struct s_data
 int		make_env(t_data *data, char **env);
 
 /* List utils */
-int		free_list(t_list **list);
-int		append(t_list **list, char *elem);
-size_t	len_list(t_list *list);
+int		free_list(t_node **list);
+int		append(t_node **list, char *elem);
+size_t	len_list(t_node *list);
 
 /* quote */
 void	quoting_choice(bool *dq, bool *sq, int *index, char c);
@@ -93,7 +93,7 @@ int		open_quote(t_data *data, char *line);
 
 /* dollar_env */
 int		exist_in_env(char *line, int *i, t_data *data);
-char	*get_elem_env(t_list *env, char *key);
+char	*get_elem_env(t_node *env, char *key);
 char	*get_dollar_word(char *line, int size);
 
 /* dollar_replace */
@@ -120,14 +120,14 @@ bool	make_env2(t_data *data);
 void	absolute_path(char **path, char *cmd, t_data *data);
 
 //ft_env.c
-int		ft_env(t_list	*env);
+int		ft_env(t_node	*env);
 //ft_export.c
-int		ft_export(char **str, t_list **env);
-bool	export(char *str, t_list **env);
+int		ft_export(char **str, t_node **env);
+bool	export(char *str, t_node **env);
 //ft_echo
 int		ft_echo(char **args);
 //ft_unset.c
-int		ft_unset(char **str, t_list **env);
+int		ft_unset(char **str, t_node **env);
 // ft_pwd
 int		ft_pwd(void);
 // ft_cd
@@ -142,7 +142,7 @@ void	free_all(t_data *data, char *err, int ext);
 bool	print_error_token(t_token *token, t_data *data);
 
 //array_utils.c
-char	**lst_to_arr(t_list *env);
+char	**lst_to_arr(t_node *env);
 void	sort_array(char **arr, int len);
 
 //list_cmd.c
@@ -171,7 +171,7 @@ bool	is_builtin(char *cmd);
 bool	launch_builtin(t_data *data, t_cmd *cmd);
 
 //find_cmd.c
-char	*find_cmd(t_data *data, char *sample, t_list *env);
+char	*find_cmd(t_data *data, char *sample, t_node *env);
 
 //exec2.c
 void	child_process(t_data *data, t_cmd *cmd, int *pip);

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -16,7 +16,7 @@
 # include <unistd.h>
 # include <stdio.h>
 # include <stdlib.h>
-# include <bsd/string.h>
+# include <strings.h>
 
 # ifndef BUFFER_SIZE
 #  define BUFFER_SIZE 32

--- a/src/builtin/ft_cd.c
+++ b/src/builtin/ft_cd.c
@@ -19,7 +19,7 @@ static void	error_malloc(void)
 
 static void	update_oldpwd(t_data *data)
 {
-	t_list	*tmp;
+	t_node	*tmp;
 	char	*test;
 	int		len;
 

--- a/src/builtin/ft_env.c
+++ b/src/builtin/ft_env.c
@@ -1,9 +1,9 @@
 
 #include "../../include/minishell.h"
 
-int	ft_env(t_list *env)
+int	ft_env(t_node *env)
 {
-	t_list	*temp;
+	t_node	*temp;
 
 	temp = env;
 	if (!temp)

--- a/src/builtin/ft_export.c
+++ b/src/builtin/ft_export.c
@@ -2,7 +2,7 @@
 #include "../../include/minishell.h"
 
 //if export and no other args
-static bool	export_no_args(t_list *env)
+static bool	export_no_args(t_node *env)
 {
 	char	**arr;
 	int		i;
@@ -47,11 +47,11 @@ static bool	valid_identifier(char *str)
 }
 
 //checks if identifier already in env
-static int	exist(char *str, t_list *env)
+static int	exist(char *str, t_node *env)
 {
 	int		i;
 	int		j;
-	t_list	*tmp;
+	t_node	*tmp;
 
 	if (!env)
 		return (-1);
@@ -77,7 +77,7 @@ static int	exist(char *str, t_list *env)
 }
 
 //export but norm
-bool	export(char *str, t_list **env)
+bool	export(char *str, t_node **env)
 {
 	int		pos;
 	int		i;
@@ -105,7 +105,7 @@ bool	export(char *str, t_list **env)
 }
 
 //export
-int	ft_export(char **str, t_list **env)
+int	ft_export(char **str, t_node **env)
 {
 	int	exit_code;
 	int	i;

--- a/src/builtin/ft_unset.c
+++ b/src/builtin/ft_unset.c
@@ -19,11 +19,11 @@ static bool	syntax(char *str)
 }
 
 //checks if identifier already in env
-static int	exist(char *str, t_list *env)
+static int	exist(char *str, t_node *env)
 {
 	int		i;
 	int		j;
-	t_list	*tmp;
+	t_node	*tmp;
 
 	if (!env)
 		return (-1);
@@ -46,11 +46,11 @@ static int	exist(char *str, t_list *env)
 	return (-1);
 }
 
-//static bool	unset(char *str, t_list **env)
+//static bool	unset(char *str, t_node **env)
 //{
 //	int		pos;
 //	int		i;
-//	t_list	**tmp;
+//	t_node	**tmp;
 
 //	if (!str || !(*str))
 //		return (false);
@@ -75,7 +75,7 @@ static int	exist(char *str, t_list *env)
 //	return (false);
 //}
 
-static void	check_env(t_list *tmp, t_list **env)
+static void	check_env(t_node *tmp, t_node **env)
 {
 	if (tmp == (*env))
 		(*env) = tmp->next;
@@ -83,11 +83,11 @@ static void	check_env(t_list *tmp, t_list **env)
 		(*env) = NULL;
 }
 
-static bool	unset(char *str, t_list **env)
+static bool	unset(char *str, t_node **env)
 {
 	int		pos;
 	int		i;
-	t_list	*tmp;
+	t_node	*tmp;
 
 	if (!str || !(*str))
 		return (false);
@@ -112,7 +112,7 @@ static bool	unset(char *str, t_list **env)
 	return (false);
 }
 
-int	ft_unset(char **str, t_list **env)
+int	ft_unset(char **str, t_node **env)
 {
 	int	exit_code;
 	int	i;

--- a/src/exec/find_cmd.c
+++ b/src/exec/find_cmd.c
@@ -18,9 +18,9 @@ int	ft_strslashjoin(char *dest, char *str, char *env, int *index)
 	return (0);
 }
 
-static char	*create_paths(t_list *env, int len)
+static char	*create_paths(t_node *env, int len)
 {
-	t_list	*tmp;
+	t_node	*tmp;
 
 	tmp = env;
 	while (len--)
@@ -39,7 +39,7 @@ static char	*cmd_not_found(char *sample)
 	return (NULL);
 }
 
-char	*find_cmd(t_data *data, char *sample, t_list *env)
+char	*find_cmd(t_data *data, char *sample, t_node *env)
 {
 	char		*paths;
 	char		path[PATH_MAX];

--- a/src/main.c
+++ b/src/main.c
@@ -5,7 +5,7 @@ pid_t	g_signal_pid;
 
 int	make_env(t_data *data, char **env)
 {
-	t_list	*list;
+	t_node	*list;
 	int		i;
 	char	*tmp;
 

--- a/src/parsing/dollar_env.c
+++ b/src/parsing/dollar_env.c
@@ -27,7 +27,7 @@ static int	end_word(char *str, char *env)
 /* return 1 si $VAR dans env sinon 0 */
 int	exist_in_env(char *line, int *i, t_data *data)
 {
-	t_list	*tmp;
+	t_node	*tmp;
 	int		len;
 
 	if (line[*i + 1] == '?' || line[*i + 1] == '$')
@@ -48,9 +48,9 @@ int	exist_in_env(char *line, int *i, t_data *data)
 	return (0);
 }
 
-char	*get_elem_env(t_list *env, char *key)
+char	*get_elem_env(t_node *env, char *key)
 {
-	t_list	*tmp;
+	t_node	*tmp;
 	int		len;
 	int		t;
 

--- a/src/utils/array_utils.c
+++ b/src/utils/array_utils.c
@@ -2,9 +2,9 @@
 #include "../../include/minishell.h"
 
 //Transform lst to array
-char	**lst_to_arr(t_list *env)
+char	**lst_to_arr(t_node *env)
 {
-	t_list	*lst;
+	t_node	*lst;
 	char	**dest;
 	int		i;
 

--- a/src/utils/list_utils.c
+++ b/src/utils/list_utils.c
@@ -1,10 +1,10 @@
 
 #include "../../include/minishell.h"
 
-int	free_list(t_list **list)
+int	free_list(t_node **list)
 {
-	t_list	*tmp;
-	t_list	*current;
+	t_node	*tmp;
+	t_node	*current;
 
 	if (!(*list))
 		return (0);
@@ -22,9 +22,9 @@ int	free_list(t_list **list)
 	return (0);
 }
 
-static int	list_new_elem_str(t_list **new, char *elem)
+static int	list_new_elem_str(t_node **new, char *elem)
 {
-	(*new) = malloc(sizeof(t_list));
+	(*new) = malloc(sizeof(t_node));
 	if (*new == NULL)
 		return (0);
 	(*new)->str = elem;
@@ -33,16 +33,16 @@ static int	list_new_elem_str(t_list **new, char *elem)
 	return (1);
 }
 
-static void	add_first(t_list **list, t_list *new)
+static void	add_first(t_node **list, t_node *new)
 {
 	(*list) = new;
 	(*list)->prev = *list;
 	(*list)->next = *list;
 }
 
-size_t	len_list(t_list *list)
+size_t	len_list(t_node *list)
 {
-	t_list	*tmp;
+	t_node	*tmp;
 	size_t	i;
 
 	if ((list))
@@ -59,9 +59,9 @@ size_t	len_list(t_list *list)
 	return (0);
 }
 
-int	append(t_list **list, char *elem)
+int	append(t_node **list, char *elem)
 {
-	t_list	*new;
+	t_node	*new;
 
 	if (!list_new_elem_str(&new, elem))
 		return (0);


### PR DESCRIPTION
## Summary
- fix path case for `libft` in Makefile and headers
- rename custom list type to avoid collision with `libft`'s `t_list`
- replace deprecated `<bsd/string.h>` with `<strings.h>`
- update all source files for new `t_node` type

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_685aa44335e8832486e63ae2a0acc284